### PR TITLE
Clarify CRC Check Failed notice, improved README & program description

### DIFF
--- a/bkutils/uart_downloader.py
+++ b/bkutils/uart_downloader.py
@@ -119,10 +119,12 @@ class UartDownloader(object):
             # self.log("Reading: Sector {:x}".format(ss+i))
             data = self.bootItf.ReadSector(ss+i)
             if data:
-                self.log("ReadSector Success: Sector {:x},".format(ss+i) + " Length {:x}".format(len(data)))
-                if len(data) != 0x1000:
+                if len(data) == 0x1000:
+                    self.log("ReadSector Success: Sector {:x},".format(ss+i) + " Length {:x}".format(len(data)))
+                else:
                     self.log("ReadSector Failed: Length not 0x1000 {:x}".format(len(data)))
                     return
+                
                 fileBuf += data
                 if self.pbar:
                     self.pbar.update(1)

--- a/bkutils/uart_downloader.py
+++ b/bkutils/uart_downloader.py
@@ -111,27 +111,26 @@ class UartDownloader(object):
 
         # Step: Read data
         i = 0
-        ss = startAddr & 0xfffff000     # 4K对齐的地址
+        ss = startAddr & 0xfffff000     # 4K aligned address (translated)
         self.log("len: {:x}".format(length))
         self.log("startAddr: {:x}".format(ss))
         
         while i < length:
-            self.log("Reading {:x}".format(ss+i))
+            # self.log("Reading: Sector {:x}".format(ss+i))
             data = self.bootItf.ReadSector(ss+i)
             if data:
-                self.log("ReadSector Success {:x}".format(ss+i) + " len {:x}".format(len(data)))
+                self.log("ReadSector Success: Sector {:x},".format(ss+i) + " Length {:x}".format(len(data)))
                 if len(data) != 0x1000:
-                    self.log("ReadSector Failed, len not 0x1000 {:x}".format(len(data)))
+                    self.log("ReadSector Failed: Length not 0x1000 {:x}".format(len(data)))
                     return
                 fileBuf += data
                 if self.pbar:
                     self.pbar.update(1)
             else:
                 #self.pbar.close()
-                self.log("ReadSector Failed {:x}".format(ss+i))
+                self.log("ReadSector Failed: {:x}".format(ss+i))
                 return
             i += 0x1000
-            self.log(i)
 
         #self.pbar.close()
         self.pbar = None
@@ -140,6 +139,7 @@ class UartDownloader(object):
             self._Do_Boot_ProtectFlash(mid, False)
 
         success, crc = self.bootItf.ReadCRC(startAddr, ss+i)
+        self.log("----- CRC check ------")
         self.log("CRC should be {:x}".format(crc))
         fileCrc = crc32_ver2(0xffffffff, fileBuf)
         self.log("CRC is {:x}".format(fileCrc))
@@ -148,12 +148,14 @@ class UartDownloader(object):
             f = open(filename, "wb")
             f.write(fileBuf)
             f.close()
+            self.log("--- CRC check PASSED ---")
             self.log("Wrote {:x} bytes to ".format(i) + filename)
         else:
             f = open(filename, "wb")
             f.write(fileBuf)
             f.close()
-            self.log("CRC check failed")
+            self.log("--- CRC check FAILED. ---")
+            self.log("If device is a BK7231N, ignore this error.")
             self.log("Wrote {:x} bytes to ".format(i) + filename)
 
         return
@@ -184,7 +186,7 @@ class UartDownloader(object):
         # time.sleep(0.1)
         self.pbar = tqdm(total=total_num, ascii=True, ncols=80, unit_scale=True,
                 unit='k', bar_format='{desc}|{bar}|[{rate_fmt:>8}]')
-        self.log("Getting Bus...")
+        self.log("Getting Bus... (waiting for connection)")
         timeout = Timeout(10)
 
         # Step2: Link Check
@@ -194,7 +196,7 @@ class UartDownloader(object):
             if r:
                 break
             if timeout.expired():
-                self.log('Cannot get bus.')
+                self.log('Cannot get bus. (cannot connect)')
                 self.pbar.close()
                 return
             count += 1
@@ -203,7 +205,7 @@ class UartDownloader(object):
                 count = 0
             # time.sleep(0.01)
 
-        self.log("Gotten Bus...")
+        self.log("Gotten Bus... (connected)")
         time.sleep(0.01)
         self.bootItf.Drain()
 
@@ -227,7 +229,7 @@ class UartDownloader(object):
         # Step4: erase
         # Step4.1: read first 4k if startAddr not aligned with 4K
         eraseAddr = startAddr
-        ss = s0 = eraseAddr & 0xfffff000     # 4K对齐的地址
+        ss = s0 = eraseAddr & 0xfffff000     # 4K aligned address (translated)
         filSPtr = 0
 
         if eraseAddr & 0xfff:
@@ -240,7 +242,7 @@ class UartDownloader(object):
             buf[eraseAddr&0xfff:eraseAddr&0xfff+fl] = pfile[:fl]
             self.bootItf.EraseBlock(0x20, s0)
             if not self.bootItf.WriteSector(s0, buf):
-                self.log("WriteSector Failed")
+                self.log("WriteSector FAILED")
                 self.pbar.close()
                 return
             filOLen -= fl
@@ -255,7 +257,7 @@ class UartDownloader(object):
 
         # Step4.2: handle the last 4K
         # now ss is the new eraseAddr.
-        # 文件结束地址
+        # file end address (translated)
         filEPtr = fileLen
         s1 = eraseAddr + fileLen
 
@@ -276,7 +278,7 @@ class UartDownloader(object):
             #    print(tt)
             #print(time.time())
             if not self.bootItf.WriteSector(s1&0xfffff000, buf):
-                self.log("WriteSector Failed")
+                self.log("WriteSector FAILED")
                 self.pbar.close()
                 return
             # print(time.time())
@@ -289,7 +291,7 @@ class UartDownloader(object):
 
         # print("Handle file end done")
 
-        # Step4.3: 对齐64KB，如果擦除区域小于64KB
+        # Step4.3: Aligned to 64KB, if the erased area is smaller than 64KB (translated)
         len1 = ss + filOLen
         len0 = s0 & 0xffff0000
         if s0 & 0xffff:
@@ -301,15 +303,15 @@ class UartDownloader(object):
 
         # print("fileOLen: {}, filSPtr: {}".format(filOLen, filSPtr))
         # Step4.4: Erase 64k, 4k, etc.
-        # 按照64KB/4K block擦除
+        # Erase according to 64KB/4K block (translated)
         len1 = ss + filOLen
         while s0 < len1:
             self.log("Erasing")
             rmn = len1 - s0
-            if rmn > 0x10000:   # 64K erase
+            if rmn > 0x10000:                       # 64K erase
                 self.bootItf.EraseBlock(0xd8, s0)
                 s0 = s0+0x10000
-            else:       # erase 4K
+            else:                                   # erase 4K
                 self.bootItf.EraseBlock(0x20, s0)
                 s0 = s0 + 0x1000
 
@@ -323,7 +325,7 @@ class UartDownloader(object):
                     self.pbar.update(1)
                     break
             else:
-                self.log("WriteSector 1 Failed")
+                self.log("WriteSector {:x} FAILED".format(1))
                 self.pbar.close()
                 return
             i += 0x1000

--- a/flash.bat
+++ b/flash.bat
@@ -1,1 +1,0 @@
-python uartprogram C:\DataNoBackup\tuya\tuya-iotos-embeded-sdk-wifi-ble-bk7231t\apps\simon_light_pwm_demo\output\1.0.0\simon_light_pwm_demo_UA_1.0.0.bin -d com4 -w

--- a/install.bat
+++ b/install.bat
@@ -1,4 +1,0 @@
-echo Do this inside a virtual environment
-pause press any key to continue, or ctrl-c to abort
-pip install hid pyserial tqdm
-python setup.py install

--- a/uartprogram
+++ b/uartprogram
@@ -4,34 +4,36 @@
 # HID Download Tool
 #
 # Copyright (c) BekenCorp. (chunjian.tian@bekencorp.com).  All rights reserved.
+# Copyright (c) 2022 OpenBekenIOT.
 #
 # This software may be distributed under the terms of the BSD license.
-# See README for more details.
+# See README.md for more details.
 
 import sys
 import os
 import argparse
 from bkutils import UartDownloader
 from bkutils import Unpackager
-# import hid
+### Disabling HID support to simplify installation
+# import hid 
 import threading
 
 # parse commandline arguments
 def parse_args():
-    description = '''Beken Uart Downloader.'''
+    description = '''Beken UART Up- and Downloader.'''
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('-d', '--device',
                         default='/dev/ttyUSB0',
-                        help="Uart device, default /dev/ttyUSB0")
+                        help="Serial device, default /dev/ttyUSB0. COM* for Windows")
     parser.add_argument('-s', '--startaddr', type=lambda  x: int(x, 16),
                         default=0x11000,
-                        help="burn flash address, defaults to 0x11000")
+                        help="burn flash address, defaults to 0x11000. Set to 0x0 for BK7231N")
     parser.add_argument('-l', '--length', type=lambda  x: int(x, 16),
                         default=0x119000,
-                        help="length to read, defaults to 0x119000")
+                        help="length to read in HEX, defaults to 0x119000 (1124 KiB). eg. 0x1F4000 = 2048KiB")
     parser.add_argument('-b', '--baudrate', type=int,
                         default=921600,
-                        help="burn uart baudrate, defaults to 921600")
+                        help="UART baudrate, defaults to 921600")
     parser.add_argument('-u', '--unprotect', action="store_true",
                         help="unprotect flash first, used by BK7231N")
     parser.add_argument('-r', '--read', action="store_true",
@@ -39,9 +41,9 @@ def parse_args():
     parser.add_argument('-w', '--write', action="store_true",
                         help="write flash")
     parser.add_argument('-p', '--unpackage', action="store_true",
-                        help="unPackage firmware")
+                        help="unPackage image")
     parser.add_argument('filename',
-                        help='specify file_crc.bin')
+                        help='path to image to read/write, REQUIRED')
     args = parser.parse_args()
 
     return args
@@ -49,11 +51,11 @@ def parse_args():
 args = parse_args()
 
 if args.unpackage:
-    Unpackager(args.filename, args.filename + '.unpackage.bin')
+    Unpackager(args.filename, args.filename + '.unpackaged.bin')
 else:
     downloader = UartDownloader(args.device, args.baudrate, args.unprotect)
+    
     if args.read:
         downloader.read(args.filename, args.startaddr, args.length)
-    else:
-        if args.write:
-            downloader.programm(args.filename, args.startaddr)
+    elif args.write:
+        downloader.programm(args.filename, args.startaddr)


### PR DESCRIPTION
- Added a clarifying note to the CRC Check Failed notice about encrypted files
- Removed some redundant log prints about the current sector being read
- Translated some remaining Chinese strings
- Amended some Description/args items
- Replaced one if-else+if with if-elif
- Updated README install instructions
- Updated README general information
- Removed unnecessary Windows `.bat` files
- Modified order of size check & error display (Picture 1)

![Picture 1](https://user-images.githubusercontent.com/16231288/205045727-3d822a06-7001-4d9f-98de-6cad3adb67f9.png)
