### PR TITLE
Fix uart write Drain timeout on "WriteSector 1 Failed"

### DIFF
--- a/bkutils/uart_downloader.py
+++ b/bkutils/uart_downloader.py
@@ -204,7 +204,7 @@ class UartDownloader(object):
             # time.sleep(0.01)
 
         self.log("Gotten Bus...")
-        time.sleep(0.01)
+        time.sleep(0.1)
         self.bootItf.Drain()
 
         # Step3: set baudrate, delay 100ms


### PR DESCRIPTION
The timout in `--write` (0.01 s) is too short. This change sets the same timeout as in `--read` (0.1 s).

You will notice that `--read` works but `--write` does not.

This fixes `Set baudrate failed` (if using a custom baud rate) or `Unprotect Failed` (if using BK7231N) or `WriteSector 1 Failed` otherwise on `--write`.